### PR TITLE
Add patch for update manager in 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,20 @@ You can resolve this by disabling the spam hooks in APT:
 sudo mv /etc/apt/apt.conf.d/20apt-esm-hook.conf /etc/apt/apt.conf.d/20apt-esm-hook.conf.disabled
 ```
 
-### Patch Update Manager (for Ubuntu 23.04+ Desktop only)
+### Patch Update Manager
+
+Known supported versions:
+- 20.04 Desktop (`updateManager2004.patch`)
+- 22.04 Desktop (`updateManager2204.patch`)
+- 23.04 Desktop (`updateManager2304.patch`)
+
 UpdateManager in Ubuntu 23.04 now hooks into ubuntu advantage.  Chabala submitted a patch to make update manager function independently again.
 
-First, test the patch can be applied cleanly:
+First, test the patch can be applied cleanly (replace `updateManager2304.patch` with the patch for your version):
 
 `wget -O - "https://raw.githubusercontent.com/Skyedra/UnspamifyUbuntu/master/updateManager2304.patch" | patch /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py --dry-run`
 
-If that doesn't cause any errors, remove the --dry-run option to actually apply it:
+If that doesn't cause any errors, remove the `--dry-run` option to actually apply it:
 
 `wget -O - "https://raw.githubusercontent.com/Skyedra/UnspamifyUbuntu/master/updateManager2304.patch" | patch /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py`
 

--- a/updateManager2204.patch
+++ b/updateManager2204.patch
@@ -1,5 +1,5 @@
 --- /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py.orig	2025-06-25 15:15:56.941726136 +0300
-+++ /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py	2025-06-25 15:41:15.808882645 +0300
++++ /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py	2025-06-25 15:43:17.614605707 +0300
 @@ -27,7 +27,7 @@
  from gi.repository import Gio
  from gi.repository import GLib
@@ -9,11 +9,12 @@
  
  GdkX11  # pyflakes
  
-@@ -281,6 +281,7 @@
-     def _get_ua_security_status(self):
-         self.ua_security_packages = []
-         self.ua_updates = []
-+        return
-         t = threading.Thread(target=self._fetch_ua_updates, daemon=True)
-         t.start()
-         while t.is_alive():
+@@ -463,7 +463,7 @@
+ 
+         self._check_oem_metapackages()
+ 
+-        self._get_ua_security_status()
++        # self._get_ua_security_status()
+ 
+         for pkgname in self.oem_metapackages:
+             try:

--- a/updateManager2204.patch
+++ b/updateManager2204.patch
@@ -1,0 +1,28 @@
+--- /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py.orig	2025-06-25 15:15:56.941726136 +0300
++++ /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py	2025-06-25 15:16:49.440516383 +0300
+@@ -27,7 +27,7 @@
+ from gi.repository import Gio
+ from gi.repository import GLib
+ from gi.repository import GObject
+-import uaclient.api.u.pro.packages.updates.v1 as ua
++# import uaclient.api.u.pro.packages.updates.v1 as ua
+ 
+ GdkX11  # pyflakes
+ 
+@@ -272,11 +272,11 @@
+                 self.oem_metapackages.add(pkg)
+ 
+     def _fetch_ua_updates(self):
+-        try:
+-            self.ua_updates = ua.updates().updates
+-        except Exception as e:
+-            print("Error running updates end-point: ", e)
+-            self.ua_updates = []
++        # try:
++        #     self.ua_updates = ua.updates().updates
++        # except Exception as e:
++        #     print("Error running updates end-point: ", e)
++        self.ua_updates = []
+ 
+     def _get_ua_security_status(self):
+         self.ua_security_packages = []

--- a/updateManager2204.patch
+++ b/updateManager2204.patch
@@ -1,5 +1,5 @@
 --- /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py.orig	2025-06-25 15:15:56.941726136 +0300
-+++ /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py	2025-06-25 15:16:49.440516383 +0300
++++ /usr/lib/python3/dist-packages/UpdateManager/UpdateManager.py	2025-06-25 15:41:15.808882645 +0300
 @@ -27,7 +27,7 @@
  from gi.repository import Gio
  from gi.repository import GLib
@@ -9,20 +9,11 @@
  
  GdkX11  # pyflakes
  
-@@ -272,11 +272,11 @@
-                 self.oem_metapackages.add(pkg)
- 
-     def _fetch_ua_updates(self):
--        try:
--            self.ua_updates = ua.updates().updates
--        except Exception as e:
--            print("Error running updates end-point: ", e)
--            self.ua_updates = []
-+        # try:
-+        #     self.ua_updates = ua.updates().updates
-+        # except Exception as e:
-+        #     print("Error running updates end-point: ", e)
-+        self.ua_updates = []
- 
+@@ -281,6 +281,7 @@
      def _get_ua_security_status(self):
          self.ua_security_packages = []
+         self.ua_updates = []
++        return
+         t = threading.Thread(target=self._fetch_ua_updates, daemon=True)
+         t.start()
+         while t.is_alive():


### PR DESCRIPTION
Hi.
Update manager in jammy (22.04) also breaks after installing the fake package.
Here is a patch to fix it.